### PR TITLE
Removes the defaultValue for input field to fix the react 15+ warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Below are is a sample of how to setup the loaders:
 
 
 ## History
+* 0.1.4 - Removes the defaultValue prop from <input/> to fix the React 15.2+ warnings
 * 0.1.3 - Minor css update on icon height
 * 0.1.0 - Initial
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-components-checkbox",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "React checkbox component",
   "main": "src/index.js",
   "scripts": {
@@ -22,6 +22,16 @@
     "url": "https://github.com/ship-components/ship-components-checkbox/issues"
   },
   "homepage": "https://github.com/ship-components/ship-components-checkbox#readme",
+  "contributors": [
+    {
+      "name": "Isaac Suttell",
+      "email": "isaac_suttell@playstation.sony.com"
+    },
+    {
+      "name": "Sepand Assadi",
+      "email": "sepand_assadi@playstation.sony.com"
+    }
+  ],
   "devDependencies": {
     "autoprefixer": "^6.1.1",
     "babel-core": "^6.14.0",

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -136,7 +136,6 @@ export default class CheckBox extends React.Component {
           readOnly={this.props.readOnly}
           type={this.props.type}
           checked={this.state.selected}
-          defaultValue={this.props.value}
           value={this.props.value || this.state.selected}
           ref='input'
         />


### PR DESCRIPTION
@isuttell @corescan: React 15.4.1 complains when passing both value and defaultValue down to the input tag. Only one is required.

PUMPED the version to 0.1.4